### PR TITLE
fix(redfish): replace parameters order

### DIFF
--- a/src/hsm/inventory/redfish_endpoint/http_client.rs
+++ b/src/hsm/inventory/redfish_endpoint/http_client.rs
@@ -336,8 +336,8 @@ pub async fn delete_all(
 }
 
 pub async fn delete_one(
-    base_url: &str,
     auth_token: &str,
+    base_url: &str,
     root_cert: &[u8],
     xname: &str,
 ) -> Result<Value, Error> {


### PR DESCRIPTION
# fix(redfish): replace parameters order

## :warning: Perhaps this fix is wrong

Perhaps the problem isn't `ochami-rs` but Manta CLI that called the delete function with arguments reversed.

## Debug workflow

In the function:

This command:

```shell
manta delete redfish-endpoint --id x0c0s0b0
```

Print this error:

```
ERROR - Message: ERROR - Net: builder error: relative URL without a base
```

After adding these debug message:

```rust
println!("base_url {}", base_url);
println!("auth_token {}", auth_token);
```

In this function:

```rust
pub async fn delete_one
```

I note that base_url and auth_token values are reversed.

After this patch, the same manta command print this:

```
Boot parameters for id 'x0c0s0b0' deleted successfully
```
